### PR TITLE
Add user profiles and match tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,22 +11,49 @@ from flask_login import (
 from flask_mail import Mail, Message
 from flask_wtf import CSRFProtect
 from werkzeug.security import generate_password_hash, check_password_hash
-from forms import LoginForm, RegisterForm, ContactForm, EventForm
+from forms import (
+    LoginForm,
+    RegisterForm,
+    ContactForm,
+    EventForm,
+    ProfileForm,
+    MatchForm,
+)
 import os
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change-me')
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
+app.config['MAIL_SERVER'] = os.environ.get('MAIL_SERVER', 'localhost')
+app.config['MAIL_PORT'] = int(os.environ.get('MAIL_PORT', 25))
+app.config['MAIL_USERNAME'] = os.environ.get('MAIL_USERNAME')
+app.config['MAIL_PASSWORD'] = os.environ.get('MAIL_PASSWORD')
+app.config['MAIL_USE_TLS'] = True
+app.config['MAIL_DEFAULT_SENDER'] = os.environ.get('MAIL_DEFAULT_SENDER', 'noreply@example.com')
 CSRFProtect(app)
 
 db = SQLAlchemy(app)
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
+mail = Mail(app)
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(150), unique=True, nullable=False)
     password_hash = db.Column(db.String(150), nullable=False)
+    team = db.Column(db.String(150))
+    school = db.Column(db.String(150))
+    club = db.Column(db.String(150))
+    height = db.Column(db.String(20))
+    weight_class = db.Column(db.String(20))
+    matches = db.relationship('Match', backref='user', lazy=True)
+
+class Match(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    opponent = db.Column(db.String(150), nullable=False)
+    date = db.Column(db.String(50), nullable=False)
+    description = db.Column(db.Text)
 
 class Event(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -79,9 +106,14 @@ def contact():
     return render_template('contact.html', form=form)
 
 @app.route('/schedule')
+def schedule():
+    events = Event.query.order_by(Event.date).all()
     form = EventForm()
     return render_template('schedule.html', events=events, form=form)
+
+@app.route('/add_event', methods=['POST'])
 @login_required
+def add_event():
     form = EventForm()
     if form.validate_on_submit():
         event = Event(
@@ -94,35 +126,27 @@ def contact():
         flash('Event added')
     else:
         flash('Invalid input')
+    return redirect(url_for('schedule'))
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
     form = LoginForm()
     if form.validate_on_submit():
         username = form.username.data
         password = form.password.data
-    return render_template('login.html', form=form)
-    form = RegisterForm()
-    if form.validate_on_submit():
-        username = form.username.data
-        password = form.password.data
-    return render_template('register.html', form=form)
-
-@app.route('/login', methods=['GET', 'POST'])
-def login():
-    if request.method == 'POST':
-        username = request.form['username']
-        password = request.form['password']
         user = User.query.filter_by(username=username).first()
         if user and check_password_hash(user.password_hash, password):
             login_user(user)
             return redirect(url_for('index'))
-        else:
-            flash('Invalid credentials')
-    return render_template('login.html')
+        flash('Invalid credentials')
+    return render_template('login.html', form=form)
 
 @app.route('/register', methods=['GET', 'POST'])
 def register():
-    if request.method == 'POST':
-        username = request.form['username']
-        password = request.form['password']
+    form = RegisterForm()
+    if form.validate_on_submit():
+        username = form.username.data
+        password = form.password.data
         if User.query.filter_by(username=username).first():
             flash('Username already exists')
         else:
@@ -132,7 +156,7 @@ def register():
             db.session.commit()
             login_user(user)
             return redirect(url_for('index'))
-    return render_template('register.html')
+    return render_template('register.html', form=form)
 
 @app.route('/logout')
 @login_required
@@ -140,8 +164,40 @@ def logout():
     logout_user()
     return redirect(url_for('index'))
 
+@app.route('/profile', methods=['GET', 'POST'])
+@login_required
+def profile():
+    form = ProfileForm(obj=current_user)
+    if form.validate_on_submit():
+        current_user.team = form.team.data
+        current_user.school = form.school.data
+        current_user.club = form.club.data
+        current_user.height = form.height.data
+        current_user.weight_class = form.weight_class.data
+        db.session.commit()
+        flash('Profile updated')
+        return redirect(url_for('profile'))
+    return render_template('profile.html', form=form)
+
+@app.route('/matches', methods=['GET', 'POST'])
+@login_required
+def matches():
+    form = MatchForm()
+    if form.validate_on_submit():
+        match = Match(
+            user=current_user,
+            opponent=form.opponent.data,
+            date=form.date.data.strftime('%Y-%m-%d'),
+            description=form.description.data,
+        )
+        db.session.add(match)
+        db.session.commit()
+        flash('Match added')
+        return redirect(url_for('matches'))
+    matches = Match.query.filter_by(user_id=current_user.id).order_by(Match.date).all()
+    return render_template('matches.html', matches=matches, form=form)
+
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))
     debug = os.environ.get('DEBUG', 'False').lower() in ('1', 'true', 'yes')
     app.run(debug=debug, host='0.0.0.0', port=port)
-    app.run(debug=True, host='0.0.0.0', port=port)

--- a/forms.py
+++ b/forms.py
@@ -22,3 +22,17 @@ class EventForm(FlaskForm):
     date = DateField('Date', validators=[DataRequired()])
     description = TextAreaField('Description', validators=[DataRequired()])
     submit = SubmitField('Add')
+
+class ProfileForm(FlaskForm):
+    team = StringField('Team')
+    school = StringField('School')
+    club = StringField('Club')
+    height = StringField('Height')
+    weight_class = StringField('Weight Class')
+    submit = SubmitField('Save')
+
+class MatchForm(FlaskForm):
+    opponent = StringField('Opponent', validators=[DataRequired()])
+    date = DateField('Date', validators=[DataRequired()])
+    description = TextAreaField('Description')
+    submit = SubmitField('Add')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Flask-Login
 Flask-SQLAlchemy
 Werkzeug
 Flask-WTF
+Flask-Mail
+

--- a/static/style.css
+++ b/static/style.css
@@ -1,18 +1,18 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@300;400;700&display=swap');
 
 body {
     font-family: 'Roboto', sans-serif;
     margin: 0;
     padding: 0;
-    background: linear-gradient(120deg, #1e3c72, #2a5298);
-    color: #333;
+    background: linear-gradient(120deg, #000000, #490000);
+    color: #f0f0f0;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
 }
 
 nav {
-    background: rgba(0, 0, 0, 0.8);
+    background: #000;
     color: #fff;
     padding: 15px 30px;
     display: flex;
@@ -23,10 +23,19 @@ nav a {
     color: #fff;
     margin-right: 20px;
     text-decoration: none;
-    font-weight: 500;
+    font-family: 'Bebas Neue', sans-serif;
+    letter-spacing: 1px;
+    font-size: 1.1rem;
 }
 nav a:hover {
-    text-decoration: underline;
+    color: #e50914;
+}
+
+h1, h2, h3 {
+    font-family: 'Bebas Neue', sans-serif;
+    color: #e50914;
+    margin-top: 0;
+    letter-spacing: 1px;
 }
 
 .container {
@@ -34,35 +43,40 @@ nav a:hover {
     max-width: 900px;
     margin: 40px auto;
     padding: 20px;
-    background: rgba(255, 255, 255, 0.95);
+    background: rgba(0, 0, 0, 0.8);
+    color: #f0f0f0;
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    border: 2px solid #e50914;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 form label {
     display: block;
     margin-top: 15px;
     font-weight: 500;
+    color: #f0f0f0;
 }
 form input,
 form textarea {
     width: 100%;
     padding: 10px;
-    border: 1px solid #ccc;
+    border: 1px solid #555;
     border-radius: 4px;
+    background: #1a1a1a;
+    color: #f0f0f0;
     box-sizing: border-box;
 }
 form button {
     margin-top: 15px;
     padding: 10px 15px;
-    background: #1e3c72;
+    background: #e50914;
     color: #fff;
     border: none;
     border-radius: 4px;
     cursor: pointer;
 }
 form button:hover {
-    background: #16345d;
+    background: #b20710;
 }
 
 ul {
@@ -71,14 +85,14 @@ ul {
 }
 .event-list li {
     padding: 8px 0;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid #555;
 }
 .event-list li:last-child {
     border-bottom: none;
 }
 .flash {
-    background: #ffefc2;
-    color: #333;
+    background: #e50914;
+    color: #fff;
     padding: 10px;
     border-radius: 4px;
     margin-bottom: 20px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,7 @@
   <title>{% block title %}FW Wrestling Club{% endblock %}</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
@@ -21,6 +21,8 @@
     <div class="nav-right">
       {% if current_user.is_authenticated %}
         <span>Logged in as {{ current_user.username }}</span>
+        <a href="{{ url_for('matches') }}">Matches</a>
+        <a href="{{ url_for('profile') }}">Profile</a>
         <a href="{{ url_for('logout') }}">Logout</a>
       {% else %}
         <a href="{{ url_for('login') }}">Login</a>

--- a/templates/matches.html
+++ b/templates/matches.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block title %}My Matches - FW Wrestling Club{% endblock %}
+{% block content %}
+<h1>Upcoming Matches</h1>
+<ul class="event-list">
+  {% for match in matches %}
+    <li>{{ match.date }} - {{ match.opponent }} - {{ match.description }}</li>
+  {% else %}
+    <li>No matches scheduled.</li>
+  {% endfor %}
+</ul>
+<h2>Add Match</h2>
+<form method="post">
+  {{ form.csrf_token }}
+  <label>Opponent</label>
+  <input type="text" name="opponent" required>
+  <label>Date</label>
+  <input type="date" name="date" required>
+  <label>Description</label>
+  <textarea name="description"></textarea>
+  <button type="submit">Add</button>
+</form>
+{% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block title %}Profile - FW Wrestling Club{% endblock %}
+{% block content %}
+<h1>Your Profile</h1>
+<form method="post">
+  {{ form.csrf_token }}
+  <label>Team</label>
+  <input type="text" name="team" value="{{ form.team.data or '' }}">
+  <label>School</label>
+  <input type="text" name="school" value="{{ form.school.data or '' }}">
+  <label>Club</label>
+  <input type="text" name="club" value="{{ form.club.data or '' }}">
+  <label>Height</label>
+  <input type="text" name="height" value="{{ form.height.data or '' }}">
+  <label>Weight Class</label>
+  <input type="text" name="weight_class" value="{{ form.weight_class.data or '' }}">
+  <button type="submit">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask-Mail dependency
- rewrite app logic with profile and match models
- update navigation for matches and profile
- implement forms and templates for user profiles and matches

## Testing
- `python -m py_compile app.py forms.py`


------
https://chatgpt.com/codex/tasks/task_e_686eb2052b2c832f9d48ee5090c97b90